### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,7 +16,7 @@ mirror and mutually exclusive subset of packages at the same time.
 This parallelism shortens whole download time. The difference of
 parallel transfer and sequential transfer gets bigger when the number
 of packages to download increases.  The connection to the remote
-server is reused accross the download, so it is very efficient.
+server is reused across the download, so it is very efficient.
 
 Prerequisites
 -------------


### PR DESCRIPTION
@tatsuhiro-t, I've corrected a typographical error in the documentation of the [apt-metalink](https://github.com/tatsuhiro-t/apt-metalink) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.